### PR TITLE
Fix duplicate order bug

### DIFF
--- a/db/queries.js
+++ b/db/queries.js
@@ -277,6 +277,12 @@ module.exports.getUserOrderCounts = async function (params, callback) {
 
 module.exports.getChatOrders = async function (params, callback) {
     const menutable = 'menudata.' + menus[params.menu].split(' ').join('_');
+
+    // count(*): gives the quantity each unique groups of (user_id, item_id, mods, sum, remarks)
+    // COALESCE(s2.sum, 0): orders with no modifiers will have s2.sum == null, this function replaces null with 0
+    // left join appends any optional modifiers to jiodata.orders table
+    // string_agg(name, ', '): concatenate all modifiers of each order into a string with delimiter == ', '
+    // group by order_id: allows sum(price) => sum of all modifier prices belonging to each order_id
     const statement = `
 		select 	t1.item_name as item, t2.remarks, t2.count, ((t1.price + t2.sum) * t2.count)::int as price, t2.mods, t2.user_id
 		from 	${menutable} t1

--- a/db/queries.js
+++ b/db/queries.js
@@ -204,7 +204,7 @@ module.exports.getUsernameFromID = async function (params, callback) {
             select 	user_name
             from 	miscellaneous.usernames
             where 	user_id = $1;`;
-        console.log(params.user_id);
+
         const args = [params.user_id];
         const res = await db.query(statement, args, callback);
         return res.rows[0].user_name;
@@ -505,7 +505,6 @@ module.exports.getOrderMessage = async function (chat_id) {
             let user = await module.exports.getUsernameFromID({
                 user_id: order.user_id,
             });
-            console.log(user);
             result += sprintf('%s - %s%s%s x%s ($%.2f)\n',
                 user, order.item, modifiers, remarks, order.count, order.price / 100.0);
         }

--- a/handlers/closejio.js
+++ b/handlers/closejio.js
@@ -102,7 +102,7 @@ module.exports.callback = async function (query) {
     }
 }
 
-const createOverviewMessage = function (menuName, closerName, compiledOrders, userOrders, deliveryFee) {
+const createOverviewMessage = async function (menuName, closerName, compiledOrders, userOrders, deliveryFee) {
     let result = 'This jio for ' + menuName + ' was successfully closed by ' + closerName + '.\n\n'
     //TODO: add jio closer name
     if (compiledOrders.length === 0) {
@@ -126,7 +126,8 @@ const createOverviewMessage = function (menuName, closerName, compiledOrders, us
     for (let i = 0; i < userOrders.length; i++) {
         let order = userOrders[i];
         if (!users.hasOwnProperty(order.user_id)) {
-            users[order.user_id] = [order.user, 0];
+            let user = await queries.getUsername(order.user_id);
+            users[order.user_id] = [user, 0];
         }
         users[order.user_id][1] += order.price;
     }

--- a/handlers/closejio.js
+++ b/handlers/closejio.js
@@ -74,7 +74,7 @@ module.exports.callback = async function (query) {
         // notify the chat
         const menuName = menus[menu];
         const closerName = query.from.first_name;
-        const text = createOverviewMessage(menuName, closerName, compiledOrders, userOrders, deliveryFee);
+        const text = await createOverviewMessage(menuName, closerName, compiledOrders, userOrders, deliveryFee);
         const message_id = await queries.getJioMessageID(chat_id);
         await messenger.send(chat_id, text, {reply_to_message_id: message_id});
         await queries.destroyListenerIds(chat_id)


### PR DESCRIPTION
When users change their name mid-ordering, duplicated bug due to sql is fixed by making a separate query for the latest username. Unfortunately, users are no longer listed alphabetically. I am not sure how to fix this. Although all orders from a single user will still be grouped together.