### PR TITLE
Use regex for bday matching

### DIFF
--- a/handlers/birthday.js
+++ b/handlers/birthday.js
@@ -10,7 +10,9 @@ module.exports.birthday = async function (msg) {
     const lowerText = originalText.toLowerCase();
     let matched = false;
     for (const str of stringsToMatch) {
-        if (lowerText.indexOf(str) === 0) {
+        let exp = str + "\\S*";
+        const regex = new RegExp(exp);
+        if (regex.test(lowerText)) {
             matched = true;
             break;
         }


### PR DESCRIPTION
Regex matches with `<bday string> + <zero or more char>`

I wasn't too sure if we want to allow `/happybday` to be a match. This implementation accepts `/happybday`, `/happybdayjohn` etc.